### PR TITLE
Contract beautifications

### DIFF
--- a/contracts/ERC6551Account.sol
+++ b/contracts/ERC6551Account.sol
@@ -43,7 +43,7 @@ contract ReferralHandlerERC6551Account is
 
     bool public initialized;
     bool private canLevel;
-    // Default tier is 1 instead of 0, since solidity 0 can also mean non-existant, all tiers in contract are real tiers 
+    // Default tier is 1 instead of 0, since solidity 0 can also mean non-existent, all tiers in contract are real tiers 
     uint8 private tier; // 0 to 5 ( 6 in total ); 0 tier - banned 
     address public referredBy; // maybe changed to referredBy address
     uint256 public mintTime;
@@ -88,7 +88,7 @@ contract ReferralHandlerERC6551Account is
         initialized = true;
         referredBy = _referredBy;
         mintTime = block.timestamp;
-        tier = 1; // Default tier is 1 instead of 0, since solidity 0 can also mean non-existant
+        tier = 1; // Default tier is 1 instead of 0, since solidity 0 can also mean non-existent
         canLevel = true;
     }
 
@@ -185,7 +185,7 @@ contract ReferralHandlerERC6551Account is
     }
 
     function updateReferralTree(uint8 refDepth) external {
-        // msg.sender should be the handler reffered by this address
+        // msg.sender should be the handler referred by this address
         require(refDepth <= 4 && refDepth >= 1, "Invalid depth");
         require(msg.sender != address(0), "Invalid referred address");
 
@@ -194,25 +194,25 @@ contract ReferralHandlerERC6551Account is
         if (refDepth == 1) {
             require(
                 firstLevelTiers[msg.sender] != 0,
-                "Cannot update non-existant entry"
+                "Cannot update non-existent entry"
             );
             firstLevelTiers[msg.sender] = _tier;
         } else if (refDepth == 2) {
             require(
                 secondLevelTiers[msg.sender] != 0,
-                "Cannot update non-existant entry"
+                "Cannot update non-existent entry"
             );
             secondLevelTiers[msg.sender] = _tier;
         } else if (refDepth == 3) {
             require(
                 thirdLevelTiers[msg.sender] != 0,
-                "Cannot update non-existant entry"
+                "Cannot update non-existent entry"
             );
             thirdLevelTiers[msg.sender] = _tier;
         } else if (refDepth == 4) {
             require(
                 fourthLevelTiers[msg.sender] != 0,
-                "Cannot update non-existant entry"
+                "Cannot update non-existent entry"
             );
             fourthLevelTiers[msg.sender] = _tier;
         }
@@ -272,7 +272,6 @@ contract ReferralHandlerERC6551Account is
      * @notice Returns number of referrals for each tier
      * @return Returns array of counts for Tiers 1 to 5 under the user
      */
-    // @audit - can be DOS'ed by having a large number of referrals
     function getTierCounts() public view returns (uint32[5] memory) {
         uint32[5] memory tierCounts; // Tiers can be 0 to 5, here we account only tiers 1 to 5 
         for (uint32 i = 0; i < firstLevelRefs.length; ++i) {

--- a/contracts/ERC6551Account.sol
+++ b/contracts/ERC6551Account.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/contracts/ERC6551Account.sol
+++ b/contracts/ERC6551Account.sol
@@ -27,7 +27,7 @@ contract ReferralHandlerERC6551Account is
     IERC6551Executable,
     IReferralHandler
 {
-    uint256 private _state; // NOTE: Not really used for anything, should be used to track the account's state
+    uint256 private _state;
 
     receive() external payable {}
     
@@ -57,7 +57,6 @@ contract ReferralHandlerERC6551Account is
 
     INexus public nexus;
 
-    // todo: bad practice of repeated tiers storing, expensive tier updates
     // Mapping of the above Handler list and their corresponding NFT tiers
     mapping(address => uint8) public firstLevelTiers;
     mapping(address => uint8) public secondLevelTiers;

--- a/contracts/ERC6551Account.sol
+++ b/contracts/ERC6551Account.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.17;
+pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/contracts/ERC6551Registry.sol
+++ b/contracts/ERC6551Registry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 import "./interfaces/IERC6551/IERC6551Registry.sol";
 

--- a/contracts/ERC6551Registry.sol
+++ b/contracts/ERC6551Registry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity 0.8.19;
 
 import "./interfaces/IERC6551/IERC6551Registry.sol";
 

--- a/contracts/EscrowNative.sol
+++ b/contracts/EscrowNative.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/interfaces/IERC20.sol";
 import "@openzeppelin/contracts/utils/Address.sol";

--- a/contracts/EscrowNative.sol
+++ b/contracts/EscrowNative.sol
@@ -37,7 +37,7 @@ contract EscrowNative is IEscrow {
         uint256 _paymentAmount
     ) external payable {   
         require(!initialized, "Already Initialized");
-        require(_token == address(0), "EscrowNative: Token address shouod be 0");
+        require(_token == address(0), "EscrowNative: Token address should be 0");
         
         initialized = true;
         quest = IQuest(msg.sender);

--- a/contracts/EscrowNative.sol
+++ b/contracts/EscrowNative.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.17;
+pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/interfaces/IERC20.sol";
 import "@openzeppelin/contracts/utils/Address.sol";

--- a/contracts/EscrowToken.sol
+++ b/contracts/EscrowToken.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/interfaces/IERC20.sol";
 import "@openzeppelin/contracts/utils/Address.sol";

--- a/contracts/EscrowToken.sol
+++ b/contracts/EscrowToken.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.17;
+pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/interfaces/IERC20.sol";
 import "@openzeppelin/contracts/utils/Address.sol";

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.17;
+pragma solidity 0.8.19;
 
 import "./interfaces/IProfileNFT.sol";
 import "./interfaces/IReferralHandler.sol";

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -73,7 +73,7 @@ contract Nexus is INexus {
     ) {
         master = msg.sender;
         accountImplementation = _accountImplementation;
-        Registry = IERC6551Registry(_registry);  // NOTE functions to updatye registry required
+        Registry = IERC6551Registry(_registry);
     }
 
     function getHandler(uint32 tokenID) external view returns (address) {

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 import "./interfaces/IProfileNFT.sol";
 import "./interfaces/IReferralHandler.sol";

--- a/contracts/ProfileNFT.sol
+++ b/contracts/ProfileNFT.sol
@@ -21,7 +21,7 @@ contract ProfileNFT is ERC721URIStorage {
     
     uint32 private _tokenCounter;
 
-    address public councelor;
+    address public counselor;
     address public nexus;
 
     event NewURI(string oldTokenURI, string newTokenURI);
@@ -31,13 +31,13 @@ contract ProfileNFT is ERC721URIStorage {
         _;
     }
 
-    modifier onlyCouncelor() {
-        require(msg.sender == councelor, "only Councelor");
+    modifier onlyCounselor() {
+        require(msg.sender == counselor, "only Counselor");
         _;
     }
 
     constructor(address _factory) ERC721("The Guild profile NFT", "GuildNFT") {
-        councelor = msg.sender;
+        counselor = msg.sender;
         nexus = _factory;
         _tokenCounter++; // Start Token IDs from 1 instead of 0, we use 0 to indicate absense of NFT on a wallet
     }
@@ -80,12 +80,11 @@ contract ProfileNFT is ERC721URIStorage {
         emit NewURI(oldURI, _tokenURI);
     }
 
-    // NOTE: Add two stp ownership to contracts
-    function setCouncelor(address account) public onlyCouncelor {
-        councelor = account;
+    function setCounselor(address account) public onlyCounselor {
+        counselor = account;
     }
 
-    function setNexus(address account) public onlyCouncelor {
+    function setNexus(address account) public onlyCounselor {
         nexus = account;
     }
 
@@ -97,7 +96,7 @@ contract ProfileNFT is ERC721URIStorage {
     function recoverTokens(
         address _token,
         address benefactor
-    ) external onlyCouncelor {
+    ) external onlyCounselor {
         if (_token == address(0)) {
             (bool sent, ) = payable(benefactor).call{
                 value: address(this).balance

--- a/contracts/ProfileNFT.sol
+++ b/contracts/ProfileNFT.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
-
 import "./interfaces/INexus.sol";
 import "./interfaces/IReferralHandler.sol";
 import "@openzeppelin/contracts/interfaces/IERC20.sol";

--- a/contracts/ProfileNFT.sol
+++ b/contracts/ProfileNFT.sol
@@ -38,7 +38,7 @@ contract ProfileNFT is ERC721URIStorage {
     constructor(address _factory) ERC721("The Guild profile NFT", "GuildNFT") {
         counselor = msg.sender;
         nexus = _factory;
-        _tokenCounter++; // Start Token IDs from 1 instead of 0, we use 0 to indicate absense of NFT on a wallet
+        _tokenCounter++; // Start Token IDs from 1 instead of 0, we use 0 to indicate absence of NFT on a wallet
     }
 
     function issueProfile(

--- a/contracts/ProfileNFT.sol
+++ b/contracts/ProfileNFT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.17;
+pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 

--- a/contracts/Quest.sol
+++ b/contracts/Quest.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 import { IEscrow } from "./interfaces/Quests/IEscrow.sol";
 import { IRewarder } from "./interfaces/IRewarder.sol";

--- a/contracts/Quest.sol
+++ b/contracts/Quest.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.17;
+pragma solidity 0.8.19;
 
 import { IEscrow } from "./interfaces/Quests/IEscrow.sol";
 import { IRewarder } from "./interfaces/IRewarder.sol";

--- a/contracts/Rewarder.sol
+++ b/contracts/Rewarder.sol
@@ -316,7 +316,6 @@ contract Rewarder is IRewarder, Pausable, ReentrancyGuard {
 
         uint256 deposit = msg.value;
 
-        // NOTE: will not be able to start dispute if depositRate is 0, and will revert
         require(deposit == ((paymentAmount * disputeDepositRate) / baseDivisor), "Wrong dispute deposit");
         
         address disputeTreasury = taxManager.disputeFeesTreasury();
@@ -331,7 +330,6 @@ contract Rewarder is IRewarder, Pausable, ReentrancyGuard {
         uint256 disputeDepositRate = taxManager.disputeDepositRate();
         uint256 baseDivisor = taxManager.taxBaseDivisor();
 
-        // NOTE: will transfer 0 if depositRate is 0, will not revert
         uint256 deposit = ((paymentAmount * disputeDepositRate) / baseDivisor);
 
         address seekerHandler = nexus.getHandler(seekerId);
@@ -380,9 +378,7 @@ contract Rewarder is IRewarder, Pausable, ReentrancyGuard {
             uint256 deposit = ((payment * disputeDepositRate) / baseDivisor);
 
             // both pay half of the dispute deposit 
-            // uint256 seekerPayment = (payment * ((baseDivisor + (disputeDepositRate / 2)) + ((100 - solverShare) * baseDivisor) / 100)) / baseDivisor;
             uint256 seekerPayment = ((payment * (baseDivisor - solverShare)) / baseDivisor) + ((deposit * 5000) / baseDivisor);
-            // uint256 solverPayment = (payment * ((baseDivisor - (disputeDepositRate / 2)) + (solverShare  * baseDivisor) / 100)) / baseDivisor;
             uint256 solverPayment = ((payment * solverShare) / baseDivisor) - ((deposit * 5000) / baseDivisor);
 
             // Sends to seeker
@@ -433,9 +429,7 @@ contract Rewarder is IRewarder, Pausable, ReentrancyGuard {
 
             uint256 deposit = ((payment * disputeDepositRate) / baseDivisor);
 
-            // uint256 seekerPayment = (payment * ((baseDivisor + (disputeDepositRate / 2)) + ((100 - solverShare) * baseDivisor) / 100)) / baseDivisor;
             uint256 seekerPayment = ((payment * (baseDivisor - solverShare)) / baseDivisor) + ((deposit * 5000) / baseDivisor);
-            // uint256 rewardValue = (payment * ((baseDivisor - (disputeDepositRate / 2)) + (solverShare  * baseDivisor) / 100)) / baseDivisor;
             uint256 solverPayment = ((payment * solverShare) / baseDivisor) - ((deposit * 5000) / baseDivisor);
             
             // Sends to seeker

--- a/contracts/Rewarder.sol
+++ b/contracts/Rewarder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.17;
+pragma solidity 0.8.19;
 
 import "./interfaces/IReferralHandler.sol";
 import "./interfaces/INexus.sol";

--- a/contracts/Rewarder.sol
+++ b/contracts/Rewarder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 import "./interfaces/IReferralHandler.sol";
 import "./interfaces/INexus.sol";

--- a/contracts/Rewarder.sol
+++ b/contracts/Rewarder.sol
@@ -14,7 +14,7 @@ import "./interfaces/IRewarder.sol";
 /**
  * @title Rewarder contract
  * @author @cosmodude
- * @notice Controls the referral and quest reward proccess
+ * @notice Controls the referral and quest reward process
  * @dev Processes native and ERC20 tokens 
  */
 contract Rewarder is IRewarder, Pausable, ReentrancyGuard {
@@ -102,7 +102,6 @@ contract Rewarder is IRewarder, Pausable, ReentrancyGuard {
     function _handleRewardNative(uint32 _solverId, uint256 _amount) private {
         address escrow = msg.sender;
 
-        // griefer can send dust values of paymentAmount and make solver unable to claim
         require(escrow.balance == 0, "Escrow not empty");
 
         ITaxManager taxManager = getTaxManager();
@@ -110,7 +109,7 @@ contract Rewarder is IRewarder, Pausable, ReentrancyGuard {
 
         uint256 rewardValue;
         // in case, want to process less than msg.value 
-        if(_amount > 1) { // for gas optimisation (0 comparison is more expensive)
+        if(_amount > 1) { // for gas optimization (0 comparison is more expensive)
             
             require(
                 _amount <= msg.value, 
@@ -516,7 +515,7 @@ contract Rewarder is IRewarder, Pausable, ReentrancyGuard {
             }
         }
 
-        // Pay out the Refferal rewards
+        // Pay out the Referral rewards
         for (uint8 i = 0; i < 4; ++i) {
             uint256 reward = rewards[i];
             rewards[i] = 0;

--- a/contracts/Tavern.sol
+++ b/contracts/Tavern.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.17;
+pragma solidity 0.8.19;
 
 import "./interfaces/IProfileNFT.sol";
 import "./interfaces/Quests/IQuest.sol";

--- a/contracts/Tavern.sol
+++ b/contracts/Tavern.sol
@@ -63,7 +63,7 @@ contract Tavern is ITavern, Pausable {
      * @param infoURI Link to the info a bout quest (flexible, decide with backend)
      */
     function createNewQuest(
-        // user identificators
+        // user identifiers
         uint32 _seekerId,
         uint32 _solverId,
         uint256 _paymentAmount,
@@ -100,11 +100,10 @@ contract Tavern is ITavern, Pausable {
      * @param _solverId Nft id of the solver of the quest
      * @param _paymentAmount Amount of Native tokens to be paid
      * @param infoURI Link to the info a bout quest (flexible, decide with backend)
-     * @param _token Address of the paymant token
+     * @param _token Address of the payment token
      */
-    // NOTE: should check and only use supported ERC20 tokens~
     function createNewQuest(
-        // user identificators
+        // user identifiers
         uint32 _seekerId,
         uint32 _solverId,
         uint256 _paymentAmount,

--- a/contracts/Tavern.sol
+++ b/contracts/Tavern.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 import "./interfaces/IProfileNFT.sol";
 import "./interfaces/Quests/IQuest.sol";

--- a/contracts/TaxCalculator.sol
+++ b/contracts/TaxCalculator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 import "./interfaces/ITaxManager.sol";
 

--- a/contracts/TaxCalculator.sol
+++ b/contracts/TaxCalculator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 import "./interfaces/ITaxManager.sol";
 

--- a/contracts/TaxManager.sol
+++ b/contracts/TaxManager.sol
@@ -8,8 +8,8 @@ import "./interfaces/ITaxManager.sol";
 /**
  * @title Tax Manager contract
  * @author @cosmodude
- * @notice Holds tax rates and pool addreses 
- * @dev Readonly contract; functions devided by pool and rate relation
+ * @notice Holds tax rates and pool addresses 
+ * @dev Readonly contract; functions divided by pool and rate relation
  */
 contract TaxManager is ITaxManager {
     using SafeERC20 for IERC20;
@@ -32,7 +32,7 @@ contract TaxManager is ITaxManager {
     // attention here
     uint256 public constant taxBaseDivisor = 10000;
 
-    mapping(uint8 => ReferralTaxRates) referralRatesByTier; // tier to refferal rates by refDepth
+    mapping(uint8 => ReferralTaxRates) referralRatesByTier; // tier to referral rates by refDepth
 
     modifier onlyCustodian() {
         // Change this to a list with ROLE library
@@ -91,7 +91,7 @@ contract TaxManager is ITaxManager {
         platformRevenuePool = _platformRevenuePool;
     }
 
-    function setreferralTaxTreasury(address _referralTaxTreasury) external onlyCustodian {
+    function setReferralTaxTreasury(address _referralTaxTreasury) external onlyCustodian {
         require(_referralTaxTreasury != address(0), "Zero address");
         referralTaxTreasury = _referralTaxTreasury;
     }

--- a/contracts/TaxManager.sol
+++ b/contracts/TaxManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/interfaces/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/TaxManager.sol
+++ b/contracts/TaxManager.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.17;
+pragma solidity 0.8.19;
+
 import "@openzeppelin/contracts/interfaces/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "./interfaces/ITaxManager.sol";

--- a/contracts/TierManager.sol
+++ b/contracts/TierManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 import "./interfaces/IReferralHandler.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/TierManager.sol
+++ b/contracts/TierManager.sol
@@ -45,7 +45,6 @@ contract TierManager is ITierManager {
         xpToken = token;
     }
 
-    // @audit - Should probably be set during the constructor as well
     function setConditions(
         uint8 tier,
         uint256 xpPoints,

--- a/contracts/TierManager.sol
+++ b/contracts/TierManager.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.17;
+pragma solidity 0.8.19;
+
 import "./interfaces/IReferralHandler.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/TierManager.sol
+++ b/contracts/TierManager.sol
@@ -14,7 +14,7 @@ import "./interfaces/ITierManager.sol";
 contract TierManager is ITierManager {
     using SafeERC20 for IERC20;
 
-    struct TierParamaters {
+    struct TierParameters {
         uint256 xpPoints;
         uint256 novicesReferred;
         uint256 adeptsReferred;
@@ -24,7 +24,7 @@ contract TierManager is ITierManager {
 
     address public magistrate;
     address public xpToken;
-    mapping(uint256 => TierParamaters) public tierUpConditions;
+    mapping(uint256 => TierParameters) public tierUpConditions;
     mapping(uint256 => uint256) public transferLimits;
 
     modifier onlyMagistrate() {
@@ -73,7 +73,6 @@ contract TierManager is ITierManager {
         uint8 tier
     ) internal view returns (bool) {
 
-        // NOTE: Crucial that these values are set after deployment, or users would be able to upgrade without meeting the requirements
         require(
             tierUpConditions[tier].xpPoints != 0,
             "Tier conditions not set"

--- a/contracts/XpToken.sol
+++ b/contracts/XpToken.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.17;
-
+pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";

--- a/contracts/XpToken.sol
+++ b/contracts/XpToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";

--- a/contracts/XpToken.sol
+++ b/contracts/XpToken.sol
@@ -12,7 +12,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  * @dev Transfers enabled only from owner address
  */
 contract GuildXp is ERC20, Ownable, ERC20Permit{
-    constructor(address owner) ERC20("GuildXp", "XP") Ownable(owner) ERC20Permit("GuildXp"){}
+    constructor(address _owner) ERC20("GuildXp", "XP") Ownable(_owner) ERC20Permit("GuildXp"){}
     
     // set decimals to 2
     function decimals() public view virtual override returns (uint8) {

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (token/ERC20/IERC20.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @dev Interface of the ERC-20 standard as defined in the ERC.

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (token/ERC20/IERC20.sol)
 
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 /**
  * @dev Interface of the ERC-20 standard as defined in the ERC.

--- a/contracts/interfaces/IERC6551/IER6551Executable.sol
+++ b/contracts/interfaces/IERC6551/IER6551Executable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 /// @dev the ERC-165 identifier for this interface is `0x51945447`
 interface IERC6551Executable {

--- a/contracts/interfaces/IERC6551/IER6551Executable.sol
+++ b/contracts/interfaces/IERC6551/IER6551Executable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 /// @dev the ERC-165 identifier for this interface is `0x51945447`
 interface IERC6551Executable {

--- a/contracts/interfaces/IERC6551/IERC6551Account.sol
+++ b/contracts/interfaces/IERC6551/IERC6551Account.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 /// @dev the ERC-165 identifier for this interface is `0x6faff5f1`
 interface IERC6551Account {

--- a/contracts/interfaces/IERC6551/IERC6551Account.sol
+++ b/contracts/interfaces/IERC6551/IERC6551Account.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 /// @dev the ERC-165 identifier for this interface is `0x6faff5f1`
 interface IERC6551Account {

--- a/contracts/interfaces/IERC6551/IERC6551Registry.sol
+++ b/contracts/interfaces/IERC6551/IERC6551Registry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 interface IERC6551Registry {
     /**

--- a/contracts/interfaces/IERC6551/IERC6551Registry.sol
+++ b/contracts/interfaces/IERC6551/IERC6551Registry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 interface IERC6551Registry {
     /**

--- a/contracts/interfaces/IERC721.sol
+++ b/contracts/interfaces/IERC721.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (token/ERC721/IERC721.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity 0.8.19;
 
 import { IERC165 } from "@openzeppelin/contracts/interfaces/IERC165.sol";
 

--- a/contracts/interfaces/IERC721.sol
+++ b/contracts/interfaces/IERC721.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (token/ERC721/IERC721.sol)
 
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 import { IERC165 } from "@openzeppelin/contracts/interfaces/IERC165.sol";
 

--- a/contracts/interfaces/INexus.sol
+++ b/contracts/interfaces/INexus.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 interface INexus {
     function isHandler(address) external view returns (bool);

--- a/contracts/interfaces/INexus.sol
+++ b/contracts/interfaces/INexus.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 interface INexus {
     function isHandler(address) external view returns (bool);

--- a/contracts/interfaces/IProfileNFT.sol
+++ b/contracts/interfaces/IProfileNFT.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 interface IProfileNFT {
     function ownerOf(uint256) external view returns (address);

--- a/contracts/interfaces/IProfileNFT.sol
+++ b/contracts/interfaces/IProfileNFT.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.20;
+pragma solidity 0.8.19;
 
 interface IProfileNFT {
     function ownerOf(uint256) external view returns (address);

--- a/contracts/interfaces/IReferralHandler.sol
+++ b/contracts/interfaces/IReferralHandler.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 interface IReferralHandler {
     function initialize(

--- a/contracts/interfaces/IReferralHandler.sol
+++ b/contracts/interfaces/IReferralHandler.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 interface IReferralHandler {
     function initialize(

--- a/contracts/interfaces/IReferralHandler.sol
+++ b/contracts/interfaces/IReferralHandler.sol
@@ -6,7 +6,7 @@ interface IReferralHandler {
         address _referredBy
     ) external;
     function setTier(uint8 _tier) external;
-    function checkReferralExistence(uint8 refdDpth, address referralHandler) view external returns (uint8 _tier);
+    function checkReferralExistence(uint8 refDepth, address referralHandler) view external returns (uint8 _tier);
     function getNftId() external view returns (uint32 nftId);
     function getNft() external view returns (address nftContract);
     function referredBy() external view returns (address referrerHandler);

--- a/contracts/interfaces/IRewarder.sol
+++ b/contracts/interfaces/IRewarder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 interface IRewarder {
     function handleRewardNative(uint32 solverId, uint256 amount) external payable;

--- a/contracts/interfaces/IRewarder.sol
+++ b/contracts/interfaces/IRewarder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 interface IRewarder {
     function handleRewardNative(uint32 solverId, uint256 amount) external payable;

--- a/contracts/interfaces/ITaxManager.sol
+++ b/contracts/interfaces/ITaxManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 interface ITaxManager {
     struct SeekerFees {

--- a/contracts/interfaces/ITaxManager.sol
+++ b/contracts/interfaces/ITaxManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 interface ITaxManager {
     struct SeekerFees {

--- a/contracts/interfaces/ITierManager.sol
+++ b/contracts/interfaces/ITierManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 interface ITierManager {
     function checkTierUpgrade(uint32[5] memory tierCounts, address account, uint8 tier) external returns (bool);

--- a/contracts/interfaces/ITierManager.sol
+++ b/contracts/interfaces/ITierManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 interface ITierManager {
     function checkTierUpgrade(uint32[5] memory tierCounts, address account, uint8 tier) external returns (bool);

--- a/contracts/interfaces/Quests/IEscrow.sol
+++ b/contracts/interfaces/Quests/IEscrow.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 interface IEscrow {
     function processPayment() external;

--- a/contracts/interfaces/Quests/IEscrow.sol
+++ b/contracts/interfaces/Quests/IEscrow.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 interface IEscrow {
     function processPayment() external;

--- a/contracts/interfaces/Quests/IQuest.sol
+++ b/contracts/interfaces/Quests/IQuest.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 interface IQuest {
     function initialize(

--- a/contracts/interfaces/Quests/IQuest.sol
+++ b/contracts/interfaces/Quests/IQuest.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 interface IQuest {
     function initialize(

--- a/contracts/interfaces/Quests/ITavern.sol
+++ b/contracts/interfaces/Quests/ITavern.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity 0.8.19;
+pragma solidity 0.8.20;
 
 interface ITavern {
 

--- a/contracts/interfaces/Quests/ITavern.sol
+++ b/contracts/interfaces/Quests/ITavern.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 interface ITavern {
 

--- a/contracts/mocks/MockEscrow.sol
+++ b/contracts/mocks/MockEscrow.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.17;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/interfaces/IERC20.sol";
 import "@openzeppelin/contracts/utils/Address.sol";

--- a/contracts/mocks/MockExecute.sol
+++ b/contracts/mocks/MockExecute.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.20;
 
 contract MockExecute {
     

--- a/contracts/mocks/MockExecuteEth.sol
+++ b/contracts/mocks/MockExecuteEth.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.20;
 
 contract MockExecuteEth {
     

--- a/contracts/mocks/MockFailReceiver.sol
+++ b/contracts/mocks/MockFailReceiver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.20;
 
 interface TargetContract {
     function recoverTokens(address _token, address _receiver) external;

--- a/contracts/mocks/MockNft.sol
+++ b/contracts/mocks/MockNft.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 

--- a/contracts/mocks/MockQuest.sol
+++ b/contracts/mocks/MockQuest.sol
@@ -23,7 +23,7 @@ contract MockQuest is IQuest {
     bool public initialized;
     bool public started;
 
-    address public escrowImplmentation; // native or with token
+    address public escrowImplementation; // native or with token
     uint32 public seekerId;
     uint32 public solverId;
     address public token;
@@ -57,7 +57,7 @@ contract MockQuest is IQuest {
         initialized = true;
 
         token = _token;
-        escrowImplmentation = _escrowImplementation;
+        escrowImplementation = _escrowImplementation;
 
         seekerId = _seekerNftId;
         solverId = _solverNftId;
@@ -74,7 +74,7 @@ contract MockQuest is IQuest {
         require(!started, "already started");
 
         started = true;
-        escrow = Clones.clone(escrowImplmentation);
+        escrow = Clones.clone(escrowImplementation);
 
         if(token == address(0)){
             IEscrow(escrow).initialize{value: msg.value}(

--- a/contracts/mocks/MockQuest.sol
+++ b/contracts/mocks/MockQuest.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.0;
+pragma solidity 0.8.20;
 
 import { IEscrow } from "../interfaces/Quests/IEscrow.sol";
 import { IRewarder } from "../interfaces/IRewarder.sol";
@@ -96,7 +96,6 @@ contract MockQuest is IQuest {
         }
     }
 
-    // todo
     function startDispute() external payable {
     }
 

--- a/contracts/mocks/MockRewarder.sol
+++ b/contracts/mocks/MockRewarder.sol
@@ -20,7 +20,7 @@ contract MockRewarder is IRewarder {
         address escrow,
         uint256 solverReward
     );
-    event ResolutionProccessed(
+    event ResolutionProcessed(
         uint32 indexed seekerId,
         uint32 indexed solverId,
         uint32 solverShare
@@ -116,7 +116,7 @@ contract MockRewarder is IRewarder {
         uint32 solverId,
         uint32 solverShare
     ) external payable override {
-        emit ResolutionProccessed(seekerId, solverId, solverShare);
+        emit ResolutionProcessed(seekerId, solverId, solverShare);
     }
 
     function processResolutionToken(
@@ -126,7 +126,7 @@ contract MockRewarder is IRewarder {
         address,
         uint256
     ) external override {
-        emit ResolutionProccessed(seekerId, solverId, solverShare);
+        emit ResolutionProcessed(seekerId, solverId, solverShare);
     }
 
     function rewardReferrers(

--- a/contracts/mocks/MockRewarder.sol
+++ b/contracts/mocks/MockRewarder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.0;
+pragma solidity 0.8.20;
 
 import "../interfaces/IRewarder.sol";
 import "../interfaces/IReferralHandler.sol";

--- a/contracts/mocks/MockTavern.sol
+++ b/contracts/mocks/MockTavern.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.0;
+pragma solidity 0.8.20;
 
 import "../interfaces/IProfileNFT.sol";
 import "../interfaces/Quests/IQuest.sol";

--- a/contracts/mocks/MockTavern.sol
+++ b/contracts/mocks/MockTavern.sol
@@ -13,7 +13,6 @@ import { ITavern } from "../interfaces/Quests/ITavern.sol";
  * @notice Deploys Quest Contracts and manages them
  * @author @cosmodude
  */
-// NOTE: the access control library isnt actually used, local access control is used instead
 contract MockTavern is ITavern {
     using SafeERC20 for IERC20;
     
@@ -63,7 +62,7 @@ contract MockTavern is ITavern {
     }
 
     function createNewQuest(
-        // user identificators
+        // user identifiers
         uint32 _seekerId,
         uint32 _solverId,
         uint256 _paymentAmount,
@@ -87,7 +86,7 @@ contract MockTavern is ITavern {
     }
 
     function createNewQuest(
-        // user identificators
+        // user identifiers
         uint32 _seekerId,
         uint32 _solverId,
         uint256 _paymentAmount,

--- a/contracts/mocks/MockToken.sol
+++ b/contracts/mocks/MockToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/mocks/SefDestruct.sol
+++ b/contracts/mocks/SefDestruct.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.20;
 
 // Still not deprecated
 // This contract is used to send ether to an address by force

--- a/test/ProfileNFT.ts
+++ b/test/ProfileNFT.ts
@@ -53,7 +53,7 @@ describe("ProfileNFT", function () {
             expect(await profileNFT.nexus()).to.equal(
                 await accounts[0].getAddress()
             );
-            expect(await profileNFT.councelor()).to.equal(
+            expect(await profileNFT.counselor()).to.equal(
                 await accounts[0].getAddress()
             );
 
@@ -154,16 +154,16 @@ describe("ProfileNFT", function () {
             await expect(
                 profileNFT_
                     .connect(accounts_[1])
-                    .setCouncelor(await accounts_[1].getAddress())
-            ).to.be.revertedWith("only Councelor");
+                    .setCounselor(await accounts_[1].getAddress())
+            ).to.be.revertedWith("only Counselor");
         });
 
         it("Councelor should be able to change the counselor address", async function () {
             await profileNFT_
                 .connect(accounts_[0])
-                .setCouncelor(await accounts_[1].getAddress());
+                .setCounselor(await accounts_[1].getAddress());
 
-            expect(await profileNFT_.councelor()).to.equal(
+            expect(await profileNFT_.counselor()).to.equal(
                 await accounts_[1].getAddress()
             );
         });
@@ -173,7 +173,7 @@ describe("ProfileNFT", function () {
                 profileNFT_
                     .connect(accounts_[2])
                     .setNexus(await accounts_[2].getAddress())
-            ).to.be.revertedWith("only Councelor");
+            ).to.be.revertedWith("only Counselor");
         });
 
         it("Councelor should be able to change the nexus address", async function () {
@@ -198,7 +198,7 @@ describe("ProfileNFT", function () {
                         mockToken_.target,
                         await accounts_[0].getAddress()
                     )
-            ).to.be.revertedWith("only Councelor");
+            ).to.be.revertedWith("only Counselor");
         });
 
         it("Councelor should be able to recover Native tokens from the contract", async function () {
@@ -276,7 +276,7 @@ describe("ProfileNFT", function () {
 
             await profileNFT_
                 .connect(accounts_[1])
-                .setCouncelor(mockFailReceiver.target);
+                .setCounselor(mockFailReceiver.target);
 
             await expect(
                 mockFailReceiver.targetRecoverTokens(profileNFT_.target)
@@ -293,7 +293,7 @@ describe("ProfileNFT", function () {
             );
 
             expect(await profileNFT.nexus()).to.equal(nexus.target);
-            expect(await profileNFT.councelor()).to.equal(
+            expect(await profileNFT.counselor()).to.equal(
                 await accounts[0].getAddress()
             );
 

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -304,7 +304,7 @@ export async function fixture_rewarder_unit_tests(accounts: Signer[]) {
 
     await taxManager.setPlatformTreasuryPool(await accounts[6].getAddress());
     await taxManager.setPlatformRevenuePool(await accounts[7].getAddress());
-    await taxManager.setreferralTaxTreasury(await accounts[8].getAddress());
+    await taxManager.setReferralTaxTreasury(await accounts[8].getAddress());
     await taxManager.setDisputeFeesTreasury(await accounts[9].getAddress());
 
     await nexus.setNFT(nft.target);
@@ -331,3 +331,5 @@ export async function fixture_rewarder_integration_tests(accounts: Signer[]) {
 
     return { rewarder, nexus, accounts, taxManager };
 }
+
+async function full_integration_fixture(accounts: Signer[]) {}


### PR DESCRIPTION
Updates
1. Use stable pragma, so `pragma solidity 0.8.20` (used 0.8.20 instead since there were some OpenZepellin import dependencies with this version) without the ^
2. Removed commented out code
4. Removed/Resolved open TODOs and NOTEs
5. Spell checked core contracts and interfaces